### PR TITLE
Fallback to delete directly from buildpack

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -25,5 +25,25 @@ if [ -f $BUILDPACK_RUN_FILE ]; then
 
   printf "...Done!\n"
 else
-  printf "${RED}Fail:${NO_COLOR} Unable to run Node Modules Cleanup script.\n"
+  # Attempt to clean node_modules directly from this buildpack.
+  if [ -f $BUILD_DIR/package.json ]; then
+    cd "$BUILD_DIR" || exit
+
+    echo "-----> Deleting node_modules/@babel..."
+    rm -rf node_modules/@babel
+
+    echo "-----> Deleting node_modules/@gusto/workbench-illos..."
+    rm -rf node_modules/@gusto/workbench-illos
+
+    echo "-----> Deleting node_modules/.cache..."
+    rm -rf node_modules/.cache
+
+    echo "-----> Deleting node_modules/flowgen..."
+    rm -rf node_modules/flowgen
+
+    echo "-----> Deleting node_modules/typescript..."
+    rm -rf node_modules/typescript
+  else
+    printf "${RED}Fail:${NO_COLOR} Unable to run Node Modules Cleanup script.\n"
+  fi
 fi

--- a/bin/detect
+++ b/bin/detect
@@ -15,11 +15,18 @@ RED='\033[0;31m'
 # Check if buildpack-run.sh file exists to ensure we can run the proper scripts
 
 MESSAGE="Node Modules Cleanup\n"
+FAIL_PREFIX="${RED}Fail:${NO_COLOR}"
 
 if [ ! -f $BUILDPACK_RUN_FILE ]; then
-  FAIL_PREFIX="${RED}Fail:${NO_COLOR}"
+  if [ -f $BUILD_DIR/package.json ]; then
+      echo MESSAGE
+      echo "Cannot find buildpack-run.sh in mithin repo. Attempting original version of node_modules cleanup..."
+      exit 0
+  fi
+
+  printf "${FAIL_PREFIX} ${MESSAGE}"
+  exit 1
 fi
 
-printf "${FAIL_PREFIX} ${MESSAGE}"
-
+printf "${MESSAGE}"
 exit 0


### PR DESCRIPTION
If no `buildpack-run.sh` found in slug, then fallback to deleting `node_modules` directly from this buildpack.